### PR TITLE
docs: add missing docstrings for ThermalEmission + StreamRTResult

### DIFF
--- a/docs/src/pages/api/core_rt.md
+++ b/docs/src/pages/api/core_rt.md
@@ -37,6 +37,13 @@ vSmartMOM.CoreRT.RTNumericalParameters
 > `surface_source_contribute!` dispatchers) are documented on the
 > [Source terms](../extending/sources.md#api-reference) page.
 
+## Stream-Level RT Output
+
+```@docs
+vSmartMOM.CoreRT.StreamRTResult
+vSmartMOM.CoreRT.rt_run_streams(::Any)
+```
+
 ## Jacobian Parameter Layout
 
 ```@docs

--- a/docs/src/pages/extending/sources.md
+++ b/docs/src/pages/extending/sources.md
@@ -212,6 +212,9 @@ vSmartMOM.CoreRT.PreparedSolarBeam
 vSmartMOM.CoreRT.BlackbodySource(::Real, ::AbstractVector{<:Real})
 vSmartMOM.CoreRT.SurfaceSIF
 vSmartMOM.CoreRT.PreparedSurfaceSIF
+vSmartMOM.CoreRT.ThermalEmission
+vSmartMOM.CoreRT.ThermalEmission(::AbstractVector{<:Real}, ::AbstractVector{<:Real})
+vSmartMOM.CoreRT.PreparedThermalEmission
 ```
 
 ### AD-mode traits
@@ -232,4 +235,6 @@ vSmartMOM.CoreRT.prepare_source(::vSmartMOM.CoreRT.SurfaceSIF, ::Type{<:Abstract
 vSmartMOM.CoreRT.prepare_sources(::vSmartMOM.CoreRT.NoSource, ::Type{<:AbstractFloat}, ::Integer, ::Integer, ::Any)
 vSmartMOM.CoreRT.surface_source_contribute!(::vSmartMOM.CoreRT.PreparedSurfaceSIF, ::Union{vSmartMOM.CoreRT.LambertianSurfaceLegendre, vSmartMOM.CoreRT.LambertianSurfaceScalar, vSmartMOM.CoreRT.LambertianSurfaceSpline}, ::Any, ::Integer, ::Any, ::Any)
 vSmartMOM.CoreRT.surface_source_contribute!(::vSmartMOM.CoreRT.NoSource, ::vSmartMOM.CoreRT.AbstractSurfaceType, ::Vararg{Any, 4})
+vSmartMOM.CoreRT.prepare_source(::vSmartMOM.CoreRT.ThermalEmission, ::Type{<:AbstractFloat}, ::Integer, ::Integer, ::Any)
+vSmartMOM.CoreRT.contribute!(::vSmartMOM.CoreRT.PreparedThermalEmission, ::Any, ::AbstractVector, ::AbstractVector, ::Integer, ::Integer, ::Any, ::Any, ::Any)
 ```


### PR DESCRIPTION
## Summary

- Fixes the Documentation CI failure on main caused by Documenter's `:missing_docs` check
- Adds 7 docstrings (from the v0.7 ThermalEmission + StreamRTResult additions) to `@docs` blocks in the CoreRT API page and the sources extension page

## Test plan

- [ ] Documentation CI passes (the only failing workflow on main)